### PR TITLE
Vereinfachung überarbeitung

### DIFF
--- a/get_label.py
+++ b/get_label.py
@@ -1,6 +1,7 @@
 # ein beispiel zur erstellung von labels mit der soap-API von dhl
 # WICHTIG! die zeep lib installieren:  https://docs.python-zeep.org/en/master/
 
+import datetime
 import os
 from requests import Session
 from requests.auth import HTTPBasicAuth
@@ -47,7 +48,7 @@ labelData = {
                 'product': 'V66WPI',
                 'accountNumber': '22222222226601',
                 'customerReference': '123ab43cSSD',
-                'shipmentDate': '2022-02-22',
+                'shipmentDate': datetime.date.today().strftime('%Y-%m-%d'),
                 'ShipmentItem': {
                     'weightInKG': 0.75,
                     'lengthInCM': 20,
@@ -56,7 +57,7 @@ labelData = {
                 },
                 'Notification': 'mail@mail.com',
                 'Service': {
-                    'Premium': {'active': '1'}, # Premium - mit tracking = 1 sonst 0
+                    'Premium': {'active': '1'},  # Premium - mit tracking = 1 sonst 0
                 }
             },
             'Shipper': {
@@ -125,5 +126,5 @@ print(result)
 
 # für mich nur wichtige daten:
 o = input_dict.get('CreationState')[0]
-print(o.get('shipmentNumber')) # tracking id
-print(o.get('LabelData').get('labelUrl')) # label download url
+print(o.get('shipmentNumber'))  # tracking id
+print(o.get('LabelData').get('labelUrl'))  # label download url

--- a/get_label.py
+++ b/get_label.py
@@ -17,20 +17,11 @@ wsdl = 'geschaeftskundenversand-api-3.2.2.wsdl'
 session = Session()
 session.auth = HTTPBasicAuth(user, password)
 
-header = xsd.Element(
-    '{http://test.python-zeep.org}Authentification',
-    xsd.ComplexType([
-        xsd.Element(
-            '{http://test.python-zeep.org}user',
-            xsd.String()),
-        xsd.Element(
-            '{http://test.python-zeep.org}signature',
-            xsd.String()),
-    ])
-)
-
-header_value = header(user='2222222222_01', signature='pass')
 client = Client(wsdl, transport=Transport(session=session))
+
+auth_header_element = client.get_element('ns0:Authentification')
+auth_header = auth_header_element(user='2222222222_01', signature='pass')
+client.set_default_soapheaders([auth_header])
 
 labelData = {
     'Version': {
@@ -122,7 +113,7 @@ if sandbox:  # Im Sandbox-Modus wird die Service-URL überschrieben
         'https://cig.dhl.de/services/sandbox/soap'
     )
 
-result = service.createShipmentOrder(_soapheaders=[header_value], **labelData)
+result = service.createShipmentOrder(**labelData)
 input_dict = helpers.serialize_object(result)
 
 os.system('clear')


### PR DESCRIPTION
Hi,

ich habe mal ein paar Änderungen/Vereinfachungen  in den Beispiel-Code eingebaut, die ich selber nutze.
Zum Einen wird die Sandbox-URL mit Hilfe von create_service überschrieben, so das man die WSDL ohne Änderung nutzen kann.
Zum Anderen wird das Authentication-Header über ein vordefiniertes Element aus der WSDL erzeugt, so dass der nicht manuell gebaut werden muss.
